### PR TITLE
Ensured shared navigation and footer requests were not broken

### DIFF
--- a/src/js/allPages.js
+++ b/src/js/allPages.js
@@ -37,7 +37,7 @@ function addScrollOffsetClass() {
  */
 function addSharedNavigation() {
   const xhr = new XMLHttpRequest();
-  const url = '../mainNavigation.html';
+  const url = './mainNavigation.html';
 
   xhr.open('GET', url);
   xhr.onload = function sharedNavFetch() {
@@ -58,7 +58,7 @@ function addSharedNavigation() {
  */
 function addSharedFooter() {
   const xhr = new XMLHttpRequest();
-  const url = '../mainFooter.html';
+  const url = './mainFooter.html';
 
   xhr.open('GET', url);
   xhr.onload = function sharedFooterFetch() {

--- a/src/js/i18next.js
+++ b/src/js/i18next.js
@@ -34,7 +34,7 @@ function changeSiteLanguage(language) {
 
 /**
  * Loads the custom i18next configuration that includes language support for English, Spanish and French.
- * Sets the fallback language to Enlish by default.
+ * Sets the fallback language to English by default.
  */
 function loadLanguageSupport() {
   // Configure i18next


### PR DESCRIPTION
Ensured shared navigation and footer requests were set as relative links to that they are accessible when deployed to GitHub pages.